### PR TITLE
Update racf.py

### DIFF
--- a/racf/racf.py
+++ b/racf/racf.py
@@ -36,7 +36,7 @@ from cogs.economy import SetParser
 
 RULES_URL = "https://www.reddit.com/r/CRRedditAlpha/comments/584ba2/reddit_alpha_clan_family_rules/"
 ROLES_URL = "https://www.reddit.com/r/CRRedditAlpha/wiki/roles"
-DISCORD_URL = "http://discord.me/racf"
+DISCORD_URL = "http://discord.gg/racf"
 
 welcome_msg = "Hi {}! Are you in the Reddit Alpha Clan Family (RACF) / " \
               "interested in joining our clans / just visiting?"


### PR DESCRIPTION
The link "http://discord.me/racf" replaced with  ''http://discord.gg/racf" to take advantage of Discord VIP Partner program providing custom link rather than using link provided by "DiscordMe" Service. Also in-line with The Reddit Alpha twitter page which shows the same link. A subtle change but link is direct now.